### PR TITLE
support user name and password when connect Hive

### DIFF
--- a/RHive/R/api.R
+++ b/RHive/R/api.R
@@ -82,9 +82,9 @@ rhive.env <- function(ALL=FALSE) {
   )
 }
 
-rhive.connect <- function(host="127.0.0.1", port=10000, hiveServer2=NA, defaultFS=NULL, updateJar=FALSE) {
+rhive.connect <- function(host="127.0.0.1", port=10000, hiveServer2=NA, defaultFS=NULL, updateJar=FALSE, user=NULL, password=NULL) {
   tryCatch ( {
-     .rhive.connect(host=host, port=port, hiveServer2=hiveServer2, defaultFS=defaultFS, updateJar=updateJar)
+     .rhive.connect(host=host, port=port, hiveServer2=hiveServer2, defaultFS=defaultFS, updateJar=updateJar, user=user, password=password)
     }, error=function(e) {
      .handleErr(e)
     }

--- a/RHive/R/rhive.R
+++ b/RHive/R/rhive.R
@@ -30,7 +30,7 @@
   System$setProperty("RHIVE_UDF_DIR", .FS_UDF_DIR())
 }
 
-.rhive.connect <- function(host="127.0.0.1", port=10000, hiveServer2=NA, defaultFS=NULL, updateJar=FALSE) {
+.rhive.connect <- function(host="127.0.0.1", port=10000, hiveServer2=NA, defaultFS=NULL, updateJar=FALSE, user=NULL, password=NULL) {
 
   if (is.null(.getEnv("HIVE_HOME")) || is.null(.getEnv("HADOOP_HOME"))) {
     warning(
@@ -52,7 +52,7 @@
     }
 
     hiveClient <- .j2r.HiveJdbcClient(hiveServer2)
-    hiveClient$connect(host, as.integer(port)) 
+    hiveClient$connect(host, as.integer(port),"default", user, password) 
     hiveClient$addJar(.FS_JAR_PATH())
 
    .registerUDFs(hiveClient)
@@ -118,22 +118,22 @@
 .makeBaseDirs <- function() {
   if (!.rhive.hdfs.exists(.FS_DATA_DIR())) {
     .dfs.mkdir(.FS_BASE_DATA_DIR())
-    .dfs.chmod("0777", .FS_BASE_DATA_DIR())
+    .dfs.chmod("777", .FS_BASE_DATA_DIR())
   }
 
   if (!.rhive.hdfs.exists(.FS_UDF_DIR())) {
     .dfs.mkdir(.FS_BASE_UDF_DIR())
-    .dfs.chmod("0777", .FS_BASE_UDF_DIR())
+    .dfs.chmod("777", .FS_BASE_UDF_DIR())
   }
 
   if (!.rhive.hdfs.exists(.FS_TMP_DIR())) {
     .dfs.mkdir(.FS_BASE_TMP_DIR())
-    .dfs.chmod("0777", .FS_BASE_TMP_DIR())
+    .dfs.chmod("777", .FS_BASE_TMP_DIR())
   }
 
   if (!.rhive.hdfs.exists(.FS_MR_SCRIPT_DIR())) {
     .dfs.mkdir(.FS_BASE_MR_SCRIPT_DIR())
-    .dfs.chmod("0777", .FS_BASE_MR_SCRIPT_DIR())
+    .dfs.chmod("777", .FS_BASE_MR_SCRIPT_DIR())
   }
 }
 


### PR DESCRIPTION
When connect hive, Rhive always connect with "Anonymous". For security reason, Rhive must possiable to connect specific user name. Java interface are exist, so i add R interface for specfic user name. 

minor : hadoop chmod can't handle 0777 no more, in hadoop-1.2.1.
